### PR TITLE
Add HTTP-based social insurance tool

### DIFF
--- a/src/mastra/agents/socialInsuranceAgent.ts
+++ b/src/mastra/agents/socialInsuranceAgent.ts
@@ -1,6 +1,6 @@
 import { Agent } from '@mastra/core/agent';
 import { openai } from '@ai-sdk/openai';
-import { mcp } from '../mcp';
+import { searchSocialInsurance } from '../tools/socialInsuranceTool';
 
 type insuredStatus = "加入中"|"未加入";
 
@@ -13,18 +13,15 @@ export type SocialInsurance = {
 };
 
 /**
- * Playwright MCP ツールとカスタムツールを組み合わせたブラウザ自動操作エージェント
+ * HTTP リクエストベースで社会保険加入状況を取得するエージェント
  */
 export const socialInsuranceAgent = new Agent({
   name: 'socialInsuranceAgent',
   model: openai('gpt-4.1-mini'),
-  tools: await mcp.getTools(),
-  instructions:  
-  `以下の手順で社会保険加入状況および被保険者人数を取得してください:\n
-  1. https://www2.nenkin.go.jp/do/search_section/にアクセス\n
-  2. 検索条件を法人番号検索に設定\n
-  3. 検索フォームに法人番号を入力して検索\n
-  4. 検索結果がない場合は加入状況は未加入\n
-  5. 検索結果がある場合は加入状況は加入中とと見做して、被保険者数を取得\n
-  6. 検索結果をTypeScript型 SocialInsurance のJSON配列として返す`,
-}); 
+  tools: { searchSocialInsurance },
+  instructions: `
+法人番号を受け取ったら searchSocialInsurance ツールを呼び出し、
+社会保険加入状況と被保険者数を取得してください。
+ユーザーへの最終出力は TypeScript 型 SocialInsurance の JSON のみとします。
+  `,
+});

--- a/src/mastra/tools/socialInsuranceTool.ts
+++ b/src/mastra/tools/socialInsuranceTool.ts
@@ -1,0 +1,62 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+import { parse } from 'node-html-parser';
+
+/**
+ * 法人番号から社会保険加入状況と被保険者数を取得するツール
+ */
+export const searchSocialInsurance = createTool({
+  id: 'searchSocialInsurance',
+  description: '法人番号で社会保険加入状況と被保険者数を取得します',
+  inputSchema: z.object({
+    corporateNumber: z.string().describe('法人番号'),
+  }),
+  outputSchema: z.object({
+    insuredStatus: z.union([z.literal('加入中'), z.literal('未加入')]),
+    insuredCount: z.number().describe('被保険者数'),
+  }),
+  execute: async ({ context: { corporateNumber } }) => {
+    // 1. 検索フォーム取得
+    const getRes = await fetch('https://www2.nenkin.go.jp/do/search_section', {
+      method: 'GET',
+      credentials: 'include',
+    });
+    if (!getRes.ok) throw new Error(`フォーム取得失敗: ${getRes.status}`);
+    const html = await getRes.text();
+
+    // 2. フォーム要素抽出
+    const doc = parse(html);
+    const form = doc.querySelector('form');
+    if (!form) throw new Error('検索フォームが見つかりませんでした');
+    const action = form.getAttribute('action');
+    if (!action) throw new Error('form action が見つかりません');
+
+    // 3. input 値を組み立て
+    const params = new URLSearchParams();
+    for (const input of form.querySelectorAll('input[name]')) {
+      const name = input.getAttribute('name') ?? '';
+      const value = input.getAttribute('value') ?? '';
+      params.append(name, name === 'houjinNumber' ? corporateNumber : value);
+    }
+
+    // 4. 検索実行
+    const postRes = await fetch(action.startsWith('http') ? action : `https://www2.nenkin.go.jp${action}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: params.toString(),
+      credentials: 'include',
+    });
+    if (!postRes.ok) throw new Error(`検索失敗: ${postRes.status} ${postRes.statusText}`);
+
+    // 5. 結果解析
+    const resultHtml = await postRes.text();
+    const resultDoc = parse(resultHtml);
+    const bodyText = resultDoc.innerText;
+    if (/該当.*ありません/.test(bodyText)) {
+      return { insuredStatus: '未加入', insuredCount: 0 } as const;
+    }
+    const countMatch = bodyText.match(/被保険者数[^\d]*(\d+)/);
+    const count = countMatch ? parseInt(countMatch[1], 10) : 0;
+    return { insuredStatus: '加入中', insuredCount: count } as const;
+  },
+});


### PR DESCRIPTION
## Summary
- replace Playwright-based social insurance agent with a fetch-based implementation
- implement `searchSocialInsurance` tool using simple form POST

## Testing
- `npm run lint` *(fails: `next` not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 法人番号から社会保険の加入状況および被保険者数を取得できる機能を追加しました。

- **リファクタ**
  - 社会保険情報の取得方法をブラウザ自動化からHTTPリクエストベースに変更し、よりシンプルで高速な処理に改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->