### PR TITLE
Add nenkin corporate search workflow

### DIFF
--- a/src/mastra/agents/browserAgent.ts
+++ b/src/mastra/agents/browserAgent.ts
@@ -1,0 +1,12 @@
+import { Agent } from '@mastra/core/agent';
+import { openai } from '@ai-sdk/openai';
+import { mcp } from '../mcp';
+
+/**
+ * Playwright MCP の全ツールを利用するブラウザ自動操作エージェント
+ */
+export const browserAgent = new Agent({
+  name: 'browserAgent',
+  model: openai('gpt-4o-mini'),
+  tools: await mcp.getTools(),
+});

--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -9,8 +9,10 @@ import { socialInsuranceAgent } from './agents/socialInsuranceAgent';
 import { fetchNewsAgent } from './agents/fetchNewsAgent';
 import { classifyRiskAgent } from './agents/classifyRiskAgent';
 import { bulletinAgent } from './agents/bulletinAgent';
+import { browserAgent } from './agents/browserAgent';
 import { companyInfoWorkflow } from './workflows/companyInfoWorkflow';
 import { prFlow, newsFlow, prAndNewsParallelWorkflow } from './workflows/prAndNewsParallelWorkflow';
+import { nenkinCorporateSearch } from './workflows/nenkinCorporateSearch';
 
 
 export const mastra = new Mastra({
@@ -21,6 +23,7 @@ export const mastra = new Mastra({
     prtimesApiAgent: prtimesApiAgent,
     nikkeiAgent: nikkeiAgent,
     socialInsuranceAgent: socialInsuranceAgent,
+    browserAgent: browserAgent,
     fetchNewsAgent: fetchNewsAgent,
     classifyRiskAgent: classifyRiskAgent,
     bulletinAgent: bulletinAgent,
@@ -30,6 +33,7 @@ export const mastra = new Mastra({
     prAndNewsParallelWorkflow,
     prFlow,
     newsFlow,
+    nenkinCorporateSearch,
   },
   logger: createLogger({
     name: "Mastra",

--- a/src/mastra/workflows/nenkinCorporateSearch.ts
+++ b/src/mastra/workflows/nenkinCorporateSearch.ts
@@ -1,0 +1,54 @@
+import { createWorkflow, createStep } from '@mastra/core/workflows/vNext';
+import { z } from 'zod';
+import { browserAgent } from '../agents/browserAgent';
+import { parse } from 'node-html-parser';
+
+/**
+ * 社会保険加入状況を取得するワークフロー
+ */
+export const nenkinCorporateSearch = createWorkflow({
+  id: 'nenkin-corporate-search',
+  inputSchema: z.object({ corporateNumber: z.string().length(13) }),
+  outputSchema: z.object({
+    insuredStatus: z.union([z.literal('加入中'), z.literal('未加入')]),
+    insuredCount: z.number(),
+  }),
+})
+  // ステップ 1: ページ遷移＋検索実行
+  .step(
+    'search',
+    createStep({
+      agent: browserAgent,
+      prompt: ({ corporateNumber }) => `
+        1) https://www2.nenkin.go.jp/do/search_section/ に移動。
+        2) ページ内で aria-label または placeholder が「法人番号」に相当する入力欄を探し、
+           値「${corporateNumber}」を入力。
+        3) 「検索実行」と書かれたボタンをクリック。
+        4) 結果テーブルが表示されるまで待機し、ページ HTML を返す。
+        返却形式: 取得した outerHTML 全体のみ。
+      `,
+    }),
+  )
+  // ステップ 2: HTML を解析し加入状況を抽出
+  .step(
+    'parse',
+    createStep({
+      inputSchema: z.object({ text: z.string() }),
+      outputSchema: z.object({
+        insuredStatus: z.union([z.literal('加入中'), z.literal('未加入')]),
+        insuredCount: z.number(),
+      }),
+      execute: async ({ inputData }) => {
+        const doc = parse(inputData.text);
+        const bodyText = doc.innerText;
+        if (/該当.*ありません/.test(bodyText)) {
+          return { insuredStatus: '未加入', insuredCount: 0 } as const;
+        }
+        const countMatch = bodyText.match(/被保険者数[^\d]*(\d+)/);
+        const count = countMatch ? parseInt(countMatch[1], 10) : 0;
+        return { insuredStatus: '加入中', insuredCount: count } as const;
+      },
+    }),
+  )
+  // ワークフローの最終出力にマッピング
+  .map(({ parse }) => parse);


### PR DESCRIPTION
## Summary
- create browserAgent for full Playwright MCP usage
- implement nenkinCorporateSearch workflow to retrieve social insurance status
- register new agent and workflow in Mastra index

## Testing
- `npm run lint` *(fails: next not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 法人番号を入力して企業の社会保険加入状況と被保険者数を検索できるワークフローを追加しました。
  - ブラウザ自動化エージェントを導入し、ウェブ検索を自動で実行できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->