### PR TITLE
Add nenkin corporate search workflow

### DIFF
--- a/src/mastra/agents/browserAgent.ts
+++ b/src/mastra/agents/browserAgent.ts
@@ -1,0 +1,17 @@
+import { Agent } from '@mastra/core/agent';
+import { openai } from '@ai-sdk/openai';
+import { mcp } from '../mcp';
+
+/**
+ * Playwright MCP の全ツールを利用するブラウザ自動操作エージェント
+ */
+export const browserAgent = new Agent({
+  name: 'browserAgent',
+  model: openai('gpt-4o-mini'),
+  tools: await mcp.getTools(),
+  instructions: `
+    あなたは Playwright MCP を利用するブラウザ操作エージェントです。
+    プロンプトで与えられた手順に従い、ページ遷移やフォーム入力、クリック操作を行ってください。
+    最終的に取得した HTML など、要求された結果のみを返してください。
+  `,
+});

--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -9,8 +9,10 @@ import { socialInsuranceAgent } from './agents/socialInsuranceAgent';
 import { fetchNewsAgent } from './agents/fetchNewsAgent';
 import { classifyRiskAgent } from './agents/classifyRiskAgent';
 import { bulletinAgent } from './agents/bulletinAgent';
+import { browserAgent } from './agents/browserAgent';
 import { companyInfoWorkflow } from './workflows/companyInfoWorkflow';
 import { prFlow, newsFlow, prAndNewsParallelWorkflow } from './workflows/prAndNewsParallelWorkflow';
+import { nenkinCorporateSearch } from './workflows/nenkinCorporateSearch';
 
 
 export const mastra = new Mastra({
@@ -21,6 +23,7 @@ export const mastra = new Mastra({
     prtimesApiAgent: prtimesApiAgent,
     nikkeiAgent: nikkeiAgent,
     socialInsuranceAgent: socialInsuranceAgent,
+    browserAgent: browserAgent,
     fetchNewsAgent: fetchNewsAgent,
     classifyRiskAgent: classifyRiskAgent,
     bulletinAgent: bulletinAgent,
@@ -30,6 +33,7 @@ export const mastra = new Mastra({
     prAndNewsParallelWorkflow,
     prFlow,
     newsFlow,
+    nenkinCorporateSearch,
   },
   logger: createLogger({
     name: "Mastra",

--- a/src/mastra/workflows/nenkinCorporateSearch.ts
+++ b/src/mastra/workflows/nenkinCorporateSearch.ts
@@ -6,6 +6,60 @@ import { parse } from 'node-html-parser';
 /**
  * 社会保険加入状況を取得するワークフロー
  */
+const searchStep = createStep({
+  id: 'search',
+  inputSchema: z.object({ corporateNumber: z.string().length(13) }),
+  outputSchema: z.object({ text: z.string() }),
+  async execute({ inputData }) {
+    // browserAgentのgenerateでプロンプトを渡してHTMLを取得
+    const prompt = `
+      1) https://www2.nenkin.go.jp/do/search_section/ に移動。
+      2) 法人番号で検索するのラジオボタンを操作して、検索方法を法人番号に設定する。
+      3) 法人番号入力欄を探し、値「${inputData.corporateNumber}」を入力。
+      4) 「検索実行」と書かれたボタンをクリック。
+      5) 結果テーブルが表示されるまで待機し、ページ HTML を返す。
+      返却形式: 取得した outerHTML 全体のみ。
+    `;
+    const res = await browserAgent.generate([{ role: 'user', content: prompt }]);
+    return { text: res.text ?? '' };
+  },
+});
+
+const parseStep = createStep({
+  id: 'parse',
+  inputSchema: z.object({ text: z.string() }),
+  outputSchema: z.object({
+    insuredStatus: z.union([z.literal('加入中'), z.literal('未加入')]),
+    insuredCount: z.number(),
+  }),
+  async execute({ inputData }) {
+    const doc = parse(inputData.text);
+
+    // テーブルのtheadから「被保険者数」の列indexを特定
+    const ths = doc.querySelectorAll('table thead tr th');
+    const insuredCountIndex = ths.findIndex(th => th.innerText.includes('被保険者数'));
+    if (insuredCountIndex === -1) {
+      // 列が見つからなければ0人扱い
+      return { insuredStatus: '未加入', insuredCount: 0 } as const;
+    }
+
+    // tbodyの最初のtrから該当列の値を取得
+    const firstRow = doc.querySelector('table tbody tr');
+    if (!firstRow) {
+      return { insuredStatus: '未加入', insuredCount: 0 } as const;
+    }
+    const tds = firstRow.querySelectorAll('td');
+    const countText = tds[insuredCountIndex]?.innerText ?? '';
+    const count = parseInt(countText.replace(/[^0-9]/g, ''), 10);
+
+    // 件数が1件以上なら「加入中」
+    return {
+      insuredStatus: count > 0 ? '加入中' : '未加入',
+      insuredCount: count || 0,
+    } as const;
+  },
+});
+
 export const nenkinCorporateSearch = createWorkflow({
   id: 'nenkin-corporate-search',
   inputSchema: z.object({ corporateNumber: z.string().length(13) }),
@@ -14,41 +68,13 @@ export const nenkinCorporateSearch = createWorkflow({
     insuredCount: z.number(),
   }),
 })
-  // ステップ 1: ページ遷移＋検索実行
-  .step(
-    'search',
-    createStep({
-      agent: browserAgent,
-      prompt: ({ corporateNumber }) => `
-        1) https://www2.nenkin.go.jp/do/search_section/ に移動。
-        2) ページ内で aria-label または placeholder が「法人番号」に相当する入力欄を探し、
-           値「${corporateNumber}」を入力。
-        3) 「検索実行」と書かれたボタンをクリック。
-        4) 結果テーブルが表示されるまで待機し、ページ HTML を返す。
-        返却形式: 取得した outerHTML 全体のみ。
-      `,
-    }),
-  )
-  // ステップ 2: HTML を解析し加入状況を抽出
-  .step(
-    'parse',
-    createStep({
-      inputSchema: z.object({ text: z.string() }),
-      outputSchema: z.object({
-        insuredStatus: z.union([z.literal('加入中'), z.literal('未加入')]),
-        insuredCount: z.number(),
-      }),
-      execute: async ({ inputData }) => {
-        const doc = parse(inputData.text);
-        const bodyText = doc.innerText;
-        if (/該当.*ありません/.test(bodyText)) {
-          return { insuredStatus: '未加入', insuredCount: 0 } as const;
-        }
-        const countMatch = bodyText.match(/被保険者数[^\d]*(\d+)/);
-        const count = countMatch ? parseInt(countMatch[1], 10) : 0;
-        return { insuredStatus: '加入中', insuredCount: count } as const;
-      },
-    }),
-  )
-  // ワークフローの最終出力にマッピング
-  .map(({ parse }) => parse);
+  .then(searchStep)
+  .map({
+    text: { step: searchStep, path: 'text' }
+  })
+  .then(parseStep)
+  .map({
+    insuredStatus: { step: parseStep, path: 'insuredStatus' },
+    insuredCount: { step: parseStep, path: 'insuredCount' }
+  })
+  .commit();

--- a/src/mastra/workflows/nenkinCorporateSearch.ts
+++ b/src/mastra/workflows/nenkinCorporateSearch.ts
@@ -1,0 +1,54 @@
+import { createWorkflow, createStep } from '@mastra/core/workflows/vNext';
+import { z } from 'zod';
+import { browserAgent } from '../agents/browserAgent';
+import { parse } from 'node-html-parser';
+
+/**
+ * 社会保険加入状況を取得するワークフロー
+ */
+export const nenkinCorporateSearch = createWorkflow({
+  id: 'nenkin-corporate-search',
+  inputSchema: z.object({ corporateNumber: z.string().length(13) }),
+  outputSchema: z.object({
+    insuredStatus: z.union([z.literal('加入中'), z.literal('未加入')]),
+    insuredCount: z.number(),
+  }),
+})
+  // ステップ 1: ページ遷移＋検索実行
+  .step(
+    'search',
+    createStep({
+      agent: browserAgent,
+      prompt: ({ corporateNumber }) => `
+        1) https://www2.nenkin.go.jp/do/search_section/ に移動。
+        2) ページ内で aria-label または placeholder が「法人番号」に相当する入力欄を探し、
+           値「${corporateNumber}」を入力。
+        3) 「検索実行」と書かれたボタンをクリック。
+        4) 結果テーブルが表示されるまで待機し、ページ HTML を返す。
+        返却形式: 取得した outerHTML 全体のみ。
+      `,
+    }),
+  )
+  // ステップ 2: HTML を解析し加入状況を抽出
+  .step(
+    'parse',
+    createStep({
+      inputSchema: z.object({ text: z.string() }),
+      outputSchema: z.object({
+        insuredStatus: z.union([z.literal('加入中'), z.literal('未加入')]),
+        insuredCount: z.number(),
+      }),
+      execute: async ({ inputData }) => {
+        const doc = parse(inputData.text);
+        const bodyText = doc.innerText;
+        if (/該当.*ありません/.test(bodyText)) {
+          return { insuredStatus: '未加入', insuredCount: 0 } as const;
+        }
+        const countMatch = bodyText.match(/被保険者数[^\d]*(\d+)/);
+        const count = countMatch ? parseInt(countMatch[1], 10) : 0;
+        return { insuredStatus: '加入中', insuredCount: count } as const;
+      },
+    }),
+  )
+  // ワークフローの最終出力にマッピング
+  .map(({ parse }) => parse);


### PR DESCRIPTION
## Summary
- create browserAgent for full Playwright MCP usage
- implement nenkinCorporateSearch workflow to retrieve social insurance status
- register new agent and workflow in Mastra index
- add missing instructions to browserAgent

## Testing
- `npm run lint` *(fails: next not found)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ブラウザ操作を自動化するエージェントを追加しました。
  - 法人番号を入力して社会保険の加入状況と被保険者数を検索できる新しいワークフローを追加しました。検索結果は構造化された形式で表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->